### PR TITLE
Only get serializer when necessary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,6 @@ $RECYCLE.BIN/
 Package/Lib
 *.nupkg
 *.zip
+
+# Rider
+.idea*

--- a/Src/FluentAssertions.Json.Net45/Json.Net45.csproj
+++ b/Src/FluentAssertions.Json.Net45/Json.Net45.csproj
@@ -42,10 +42,6 @@
     <Reference Include="FluentAssertions.Core, Version=4.19.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\FluentAssertions.4.19.0\lib\net45\FluentAssertions.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Lib\UnitTesting\Net45\Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll</HintPath>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/Src/FluentAssertions.Json.Shared/ObjectDiffPatch.cs
+++ b/Src/FluentAssertions.Json.Shared/ObjectDiffPatch.cs
@@ -59,7 +59,6 @@ namespace FluentAssertions.Json
         public static ObjectDiffPatchResult GenerateDiff<T>(T original, T updated) where T : class
         {
             // ensure the serializer will not ignore null values
-            var writer = GetJsonSerializer();
             // parse our objects
             JObject originalJson, updatedJson;
             if (typeof(JObject).IsAssignableFrom(typeof(T)))
@@ -69,6 +68,8 @@ namespace FluentAssertions.Json
             }
             else
             {
+                var writer = GetJsonSerializer();
+
                 originalJson = original != null ? JObject.FromObject(original, writer) : null;
                 updatedJson = updated != null ? JObject.FromObject(updated, writer) : null;
             }

--- a/Src/FluentAssertions.nuspec
+++ b/Src/FluentAssertions.nuspec
@@ -27,6 +27,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\Artifacts\Json\lib\**.*.*" target="lib" exclude="**\Newtonsoft.*;**\FluentAssertions.???;**\FluentAssertions.Core.???" />
+    <file src="..\Artifacts\Json\lib\**.*.*" target="lib" exclude="**\Newtonsoft.*;**\FluentAssertions.???;**\FluentAssertions.Core.???;**\Microsoft.VisualStudio.QualityTools.UnitTestFramework.???" />
   </files>
 </package>


### PR DESCRIPTION
The `writer` is only used in the else branch.
This is purely motivated by an analysis tool suggestion.