### PR TITLE
Update to FluentAssertions 5.10.2

### DIFF
--- a/Src/FluentAssertions.Json/Common/StringExtensions.cs
+++ b/Src/FluentAssertions.Json/Common/StringExtensions.cs
@@ -43,18 +43,10 @@ namespace FluentAssertions.Json.Common
         }
 
         /// <summary>
-        /// Replaces all characters that might conflict with formatting placeholders and newlines with their escaped counterparts.
+        /// Replaces all characters that might conflict with formatting placeholders with their escaped counterparts.
         /// </summary>
-        public static string Escape(this string value, bool escapePlaceholders = false)
-        {
-            value = value.Replace("\"", "\\\"").Replace("\n", @"\n").Replace("\r", @"\r");
-            if (escapePlaceholders)
-            {
-                value = value.Replace("{", "{{").Replace("}", "}}");
-            }
-
-            return value;
-        }
+        public static string EscapePlaceholders(this string value) =>
+            value.Replace("{", "{{").Replace("}", "}}");
 
         /// <summary>
         /// Joins a string with one or more other strings using a specified separator.

--- a/Src/FluentAssertions.Json/FluentAssertions.Json.csproj
+++ b/Src/FluentAssertions.Json/FluentAssertions.Json.csproj
@@ -12,7 +12,7 @@
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.0.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.2" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 </Project>

--- a/Src/FluentAssertions.Json/JTokenAssertions.cs
+++ b/Src/FluentAssertions.Json/JTokenAssertions.cs
@@ -90,9 +90,9 @@ namespace FluentAssertions.Json
 
             var message = $"JSON document {difference?.ToString().Escape(true)}.{Environment.NewLine}" +
                           $"Actual document{Environment.NewLine}" +
-                          $"{Format(Subject, true).Escape(true)}{Environment.NewLine}" +
+                          $"{Format(Subject, true).Replace("{", "{{").Replace("}", "}}")}{Environment.NewLine}" +
                           $"was expected to be equivalent to{Environment.NewLine}" +
-                          $"{Format(expected, true).Escape(true)}{Environment.NewLine}" +
+                          $"{Format(expected, true).Replace("{", "{{").Replace("}", "}}")}{Environment.NewLine}" +
                           "{reason}.";
              
             Execute.Assertion

--- a/Src/FluentAssertions.Json/JTokenAssertions.cs
+++ b/Src/FluentAssertions.Json/JTokenAssertions.cs
@@ -88,11 +88,11 @@ namespace FluentAssertions.Json
         {
             Difference difference = JTokenDifferentiator.FindFirstDifference(Subject, expected);
 
-            var message = $"JSON document {difference?.ToString().Escape(true)}.{Environment.NewLine}" +
+            var message = $"JSON document {difference?.ToString().EscapePlaceholders()}.{Environment.NewLine}" +
                           $"Actual document{Environment.NewLine}" +
-                          $"{Format(Subject, true).Replace("{", "{{").Replace("}", "}}")}{Environment.NewLine}" +
+                          $"{Format(Subject, true).EscapePlaceholders()}{Environment.NewLine}" +
                           $"was expected to be equivalent to{Environment.NewLine}" +
-                          $"{Format(expected, true).Replace("{", "{{").Replace("}", "}}")}{Environment.NewLine}" +
+                          $"{Format(expected, true).EscapePlaceholders()}{Environment.NewLine}" +
                           "{reason}.";
              
             Execute.Assertion
@@ -301,7 +301,7 @@ namespace FluentAssertions.Json
             Execute.Assertion
                 .ForCondition(jToken != null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected JSON document {0} to have element \"" + expected.Escape(true) + "\"{reason}" +
+                .FailWith("Expected JSON document {0} to have element \"" + expected.EscapePlaceholders() + "\"{reason}" +
                           ", but no such element was found.", Subject);
 
             return new AndWhichConstraint<JTokenAssertions, JToken>(this, jToken);
@@ -326,7 +326,7 @@ namespace FluentAssertions.Json
             Execute.Assertion
                 .ForCondition(jToken == null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect JSON document {0} to have element \"" + unexpected.Escape(true) + "\"{reason}.", Subject);
+                .FailWith("Did not expect JSON document {0} to have element \"" + unexpected.EscapePlaceholders() + "\"{reason}.", Subject);
 
             return new AndWhichConstraint<JTokenAssertions, JToken>(this, jToken);
         }

--- a/Tests/FluentAssertions.Json.Net45.Specs/Json.Net45.Specs.csproj
+++ b/Tests/FluentAssertions.Json.Net45.Specs/Json.Net45.Specs.csproj
@@ -37,8 +37,9 @@
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=5.0.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a">
-      <HintPath>..\..\packages\FluentAssertions.5.0.0\lib\net45\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=5.10.2.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a">
+      <HintPath>..\..\packages\FluentAssertions.5.10.2\lib\net45\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -51,8 +52,9 @@
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
     </Reference>
-    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/Tests/FluentAssertions.Json.Net45.Specs/packages.config
+++ b/Tests/FluentAssertions.Json.Net45.Specs/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="5.0.0" targetFramework="net451" />
+  <package id="FluentAssertions" version="5.10.2" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
   <package id="System.Collections" version="4.0.11" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net451" />
@@ -30,7 +30,7 @@
   <package id="System.Threading" version="4.0.11" targetFramework="net451" />
   <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net451" />
   <package id="System.Threading.Timer" version="4.0.1" targetFramework="net451" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net451" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net451" />
   <package id="System.Xml.ReaderWriter" version="4.0.11" targetFramework="net451" />
   <package id="System.Xml.XDocument" version="4.0.11" targetFramework="net451" />
   <package id="xunit" version="2.2.0" targetFramework="net451" />


### PR DESCRIPTION
This update reveals a mismatch in escaping new line characters.
Fixed by not replacing new line characters in JSON documents any more.