### PR TITLE
Improve error messages for ContainSubtree

### DIFF
--- a/Src/FluentAssertions.Json/JTokenAssertions.cs
+++ b/Src/FluentAssertions.Json/JTokenAssertions.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics;
-using System.Linq;
 using FluentAssertions.Collections;
 using FluentAssertions.Json.Common;
 using FluentAssertions.Execution;
@@ -86,12 +85,20 @@ namespace FluentAssertions.Json
         public AndConstraint<JTokenAssertions> BeEquivalentTo(JToken expected, string because = "",
             params object[] becauseArgs)
         {
-            Difference difference = JTokenDifferentiator.FindFirstDifference(Subject, expected);
+            return BeEquivalentTo(expected, false, because, becauseArgs);
+        }
+
+        private AndConstraint<JTokenAssertions> BeEquivalentTo(JToken expected, bool ignoreExtraProperties, string because = "",
+            params object[] becauseArgs)
+        {
+            Difference difference = JTokenDifferentiator.FindFirstDifference(Subject, expected, ignoreExtraProperties);
+
+            var expectation = ignoreExtraProperties ? "was expected to contain" : "was expected to be equivalent to";
 
             var message = $"JSON document {difference?.ToString().EscapePlaceholders()}.{Environment.NewLine}" +
                           $"Actual document{Environment.NewLine}" +
                           $"{Format(Subject, true).EscapePlaceholders()}{Environment.NewLine}" +
-                          $"was expected to be equivalent to{Environment.NewLine}" +
+                          $"{expectation}{Environment.NewLine}" +
                           $"{Format(expected, true).EscapePlaceholders()}{Environment.NewLine}" +
                           "{reason}.";
              
@@ -373,45 +380,9 @@ namespace FluentAssertions.Json
                 return new AndConstraint<JTokenAssertions>(this);
             }
         }
-        
-        /// <summary>
-        /// Recursively asserts that the current <see cref="JToken"/> contains at least the properties or elements of the specified <see cref="JToken"/>.
-        /// </summary>
-        /// <param name="subtree">The subtree to search for</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="because" />.
-        /// </param>
-        /// <remarks>Use this method to match the current <see cref="JToken"/> against an arbitrary subtree, 
-        /// permitting it to contain any additional properties or elements. This way we can test multiple properties on a <see cref="JObject"/> at once,
-        /// or test if a <see cref="JArray"/> contains any items that match a set of properties, assert that a JSON document has a given shape, etc. </remarks>
-        /// <example>
-        /// This example asserts the values of multiple properties of a child object within a JSON document.
-        /// <code>
-        /// var json = JToken.Parse("{ success: true, data: { id: 123, type: 'my-type', name: 'Noone' } }");
-        /// json.Should().ContainSubtree(JToken.Parse("{ success: true, data: { type: 'my-type', name: 'Noone' } }"));
-        /// </code>
-        /// </example>
-        /// <example>This example asserts that a <see cref="JArray"/> within a <see cref="JObject"/> has at least one element with at least the given properties</example>
-        /// <code>
-        /// var json = JToken.Parse("{ id: 1, items: [ { id: 2, type: 'my-type', name: 'Alpha' }, { id: 3, type: 'other-type', name: 'Bravo' } ] }");
-        /// json.Should().ContainSubtree(JToken.Parse("{ items: [ { type: 'my-type', name: 'Alpha' } ] }"));
-        /// </code>
-        public AndConstraint<JTokenAssertions> ContainSubtree(JToken subtree, string because = "", params object[] becauseArgs)
-        {
-            Execute.Assertion
-                .ForCondition(JTokenContainsSubtree(Subject, subtree))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected JSON document to contain subtree {0} {reason}, but some elements were missing.", subtree); // todo: report exact cause of failure, eg. name of the missing property, etc.
-
-            return new AndConstraint<JTokenAssertions>(this);
-        }
 
         /// <summary>
-        /// Recursively asserts that the current <see cref="JToken"/> contains at least the properties or elements of the specified <see cref="JToken"/>.
+        /// Recursively asserts that the current <see cref="JToken"/> contains at least the properties or elements of the specified <paramref name="substree"/>.
         /// </summary>
         /// <param name="subtree">The subtree to search for</param>
         /// <param name="because">
@@ -455,43 +426,35 @@ namespace FluentAssertions.Json
             return ContainSubtree(subtreeToken, because, becauseArgs);
         }
 
-        private bool JTokenContainsSubtree(JToken token, JToken subtree)
+        /// <summary>
+        /// Recursively asserts that the current <see cref="JToken"/> contains at least the properties or elements of the specified <paramref name="substree"/>.
+        /// </summary>
+        /// <param name="subtree">The subtree to search for</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        /// <remarks>Use this method to match the current <see cref="JToken"/> against an arbitrary subtree, 
+        /// permitting it to contain any additional properties or elements. This way we can test multiple properties on a <see cref="JObject"/> at once,
+        /// or test if a <see cref="JArray"/> contains any items that match a set of properties, assert that a JSON document has a given shape, etc. </remarks>
+        /// <example>
+        /// This example asserts the values of multiple properties of a child object within a JSON document.
+        /// <code>
+        /// var json = JToken.Parse("{ success: true, data: { id: 123, type: 'my-type', name: 'Noone' } }");
+        /// json.Should().ContainSubtree(JToken.Parse("{ success: true, data: { type: 'my-type', name: 'Noone' } }"));
+        /// </code>
+        /// </example>
+        /// <example>This example asserts that a <see cref="JArray"/> within a <see cref="JObject"/> has at least one element with at least the given properties</example>
+        /// <code>
+        /// var json = JToken.Parse("{ id: 1, items: [ { id: 2, type: 'my-type', name: 'Alpha' }, { id: 3, type: 'other-type', name: 'Bravo' } ] }");
+        /// json.Should().ContainSubtree(JToken.Parse("{ items: [ { type: 'my-type', name: 'Alpha' } ] }"));
+        /// </code>
+        public AndConstraint<JTokenAssertions> ContainSubtree(JToken subtree, string because = "", params object[] becauseArgs)
         {
-            switch (subtree.Type)
-            {
-                case JTokenType.Object:
-                {
-                    var sub = (JObject)subtree;
-                    var obj = token as JObject;
-                    if (obj == null)
-                        return false;
-                    foreach (var subProp in sub.Properties())
-                    {
-                        var prop = obj.Property(subProp.Name);
-                        if (prop == null)
-                            return false;
-                        if (!JTokenContainsSubtree(prop.Value, subProp.Value))
-                            return false;
-                    }
-                    return true;
-                }
-                case JTokenType.Array:
-                {
-                    var sub = (JArray)subtree;
-                    var arr = token as JArray;
-                    if (arr == null)
-                        return false;
-                    foreach (var subItem in sub)
-                    {
-                        if (!arr.Any(item => JTokenContainsSubtree(item, subItem)))
-                            return false;
-                    }
-                    return true;
-                }
-                default:
-                    return JToken.DeepEquals(token, subtree);
-
-            }
+            return BeEquivalentTo(subtree, true, because, becauseArgs);
         }
 
         public string Format(JToken value, bool useLineBreaks = false)

--- a/Src/FluentAssertions.Json/JTokenDifferentiator.cs
+++ b/Src/FluentAssertions.Json/JTokenDifferentiator.cs
@@ -66,17 +66,17 @@ namespace FluentAssertions.Json
 
         private static Difference CompareExpectedItems(JArray actual, JArray expected, JPath path)
         {
-            JEnumerable<JToken> actualChildren = actual.Children();
-            JEnumerable<JToken> expectedChildren = expected.Children();
+            JToken[] actualChildren = actual.Children().ToArray();
+            JToken[] expectedChildren = expected.Children().ToArray();
 
             int matchingIndex = 0;
-            for (int expectedIndex = 0; expectedIndex < expectedChildren.Count(); expectedIndex++)
+            for (int expectedIndex = 0; expectedIndex < expectedChildren.Length; expectedIndex++)
             {
-                var expectedChild = expectedChildren.ElementAt(expectedIndex);
+                var expectedChild = expectedChildren[expectedIndex];
                 bool match = false;
-                for (int actualIndex = matchingIndex; actualIndex < actualChildren.Count(); actualIndex++)
+                for (int actualIndex = matchingIndex; actualIndex < actualChildren.Length; actualIndex++)
                 {
-                    var difference = FindFirstDifference(actualChildren.ElementAt(actualIndex), expectedChild, true);
+                    var difference = FindFirstDifference(actualChildren[actualIndex], expectedChild, true);
 
                     if (difference == null)
                     {
@@ -88,9 +88,9 @@ namespace FluentAssertions.Json
 
                 if (!match)
                 {
-                    if (matchingIndex >= actualChildren.Count())
+                    if (matchingIndex >= actualChildren.Length)
                     {
-                        if (actual.Children().Any(actualChild => FindFirstDifference(actualChild, expectedChild, true) == null))
+                        if (actualChildren.Any(actualChild => FindFirstDifference(actualChild, expectedChild, true) == null))
                         {
                             return new Difference(DifferenceKind.WrongOrder, path.AddIndex(expectedIndex));
                         }
@@ -98,7 +98,7 @@ namespace FluentAssertions.Json
                         return new Difference(DifferenceKind.ActualMissesElement, path.AddIndex(expectedIndex));
                     }
 
-                    return FindFirstDifference(actualChildren.ElementAt(matchingIndex), expectedChild,
+                    return FindFirstDifference(actualChildren[matchingIndex], expectedChild,
                         path.AddIndex(expectedIndex), true);
                 }
             }
@@ -108,17 +108,17 @@ namespace FluentAssertions.Json
 
         private static Difference CompareItems(JArray actual, JArray expected, JPath path)
         {
-            JEnumerable<JToken> actualChildren = actual.Children();
-            JEnumerable<JToken> expectedChildren = expected.Children();
+            JToken[] actualChildren = actual.Children().ToArray();
+            JToken[] expectedChildren = expected.Children().ToArray();
 
-            if (actualChildren.Count() != expectedChildren.Count())
+            if (actualChildren.Length != expectedChildren.Length)
             {
-                return new Difference(DifferenceKind.DifferentLength, path, actualChildren.Count(), expectedChildren.Count());
+                return new Difference(DifferenceKind.DifferentLength, path, actualChildren.Length, expectedChildren.Length);
             }
 
-            for (int i = 0; i < actualChildren.Count(); i++)
+            for (int i = 0; i < actualChildren.Length; i++)
             {
-                Difference firstDifference = FindFirstDifference(actualChildren.ElementAt(i), expectedChildren.ElementAt(i), 
+                Difference firstDifference = FindFirstDifference(actualChildren[i], expectedChildren[i], 
                     path.AddIndex(i), false);
 
                 if (firstDifference != null)

--- a/Tests/FluentAssertions.Json.Shared.Specs/JTokenAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Json.Shared.Specs/JTokenAssertionsSpecs.cs
@@ -89,20 +89,20 @@ namespace FluentAssertions.Json
                 };
                 yield return new object[]
                 {
-                    "{ items: [ \"fork\", \"knife\" , \"spoon\" ]}",
-                    "{ items: [ \"fork\", \"knife\" ]}",
+                    "{ items: [ \"fork\", \"knife\" , \"spoon\" ] }",
+                    "{ items: [ \"fork\", \"knife\" ] }",
                     "has 3 elements instead of 2 at $.items"
                 };
                 yield return new object[]
                 {
-                    "{ items: [ \"fork\", \"knife\" ]}",
-                    "{ items: [ \"fork\", \"knife\" , \"spoon\" ]}",
+                    "{ items: [ \"fork\", \"knife\" ] }",
+                    "{ items: [ \"fork\", \"knife\" , \"spoon\" ] }",
                     "has 2 elements instead of 3 at $.items"
                 };
                 yield return new object[]
                 {
-                    "{ items: [ \"fork\", \"knife\" , \"spoon\" ]}",
-                    "{ items: [ \"fork\", \"spoon\", \"knife\" ]}",
+                    "{ items: [ \"fork\", \"knife\" , \"spoon\" ] }",
+                    "{ items: [ \"fork\", \"spoon\", \"knife\" ] }",
                     "has a different value at $.items[1]"
                 };
                 yield return new object[]
@@ -987,25 +987,6 @@ namespace FluentAssertions.Json
         }
 
         [Fact]
-        public void When_subtree_properties_are_missing_ContainSubtree_should_fail()
-        {
-            //-----------------------------------------------------------------------------------------------------------
-            // Arrange
-            //-----------------------------------------------------------------------------------------------------------
-            var subject = JToken.Parse("{ foo: 'foo', bar: 'bar' } ");
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Act
-            //-----------------------------------------------------------------------------------------------------------
-            Action act = () => subject.Should().ContainSubtree(" { baz: 'baz' } ");
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Assert
-            //-----------------------------------------------------------------------------------------------------------
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
         public void When_deep_subtree_matches_ContainSubtree_should_succeed()
         {
             //-----------------------------------------------------------------------------------------------------------
@@ -1022,25 +1003,6 @@ namespace FluentAssertions.Json
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_deep_subtree_does_not_match_ContainSubtree_should_fail()
-        {
-            //-----------------------------------------------------------------------------------------------------------
-            // Arrange
-            //-----------------------------------------------------------------------------------------------------------
-            var subject = JToken.Parse("{ foo: 'foo', bar: 'bar', child: { x: 1, y: 2, grandchild: { tag: 'abrakadabra' }  }} ");
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Act
-            //-----------------------------------------------------------------------------------------------------------
-            Action act = () => subject.Should().ContainSubtree(" { child: { grandchild: { tag: 'ooops' } } } ");
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Assert
-            //-----------------------------------------------------------------------------------------------------------
-            act.Should().Throw<XunitException>();
         }
 
         [Fact]
@@ -1062,42 +1024,134 @@ namespace FluentAssertions.Json
             act.Should().NotThrow();
         }
 
-        [Fact]
-        public void When_array_elements_are_missing_ContainSubtree_should_fail()
+        public static IEnumerable<object[]> FailingContainSubtreeCases
         {
-            //-----------------------------------------------------------------------------------------------------------
-            // Arrange
-            //-----------------------------------------------------------------------------------------------------------
-            var subject = JToken.Parse("{ foo: 'foo', bar: 'bar', items: [ { id: 1 }, { id: 3 }, { id: 5 } ] } ");
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Act
-            //-----------------------------------------------------------------------------------------------------------
-            Action act = () => subject.Should().ContainSubtree(" { items: [ { id: 1 }, { id: 2 } ] } ");
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Assert
-            //-----------------------------------------------------------------------------------------------------------
-            act.Should().Throw<XunitException>();
+            get
+            {
+                yield return new object[]
+                {
+                    null,
+                    "{ id: 2 }",
+                    "is null"
+                };
+                yield return new object[]
+                {
+                    "{ id: 1 }",
+                    null,
+                    "is not null"
+                };
+                yield return new object[]
+                {
+                    "{ foo: 'foo', bar: 'bar' }",
+                    "{ baz: 'baz' }",
+                    "misses property $.baz"
+                };
+                yield return new object[]
+                {
+                    "{ items: [] }",
+                    "{ items: 2 }",
+                    "has an array instead of an integer at $.items"
+                };
+                yield return new object[]
+                {
+                    "{ items: [ \"fork\", \"knife\" ] }",
+                    "{ items: [ \"fork\", \"knife\" , \"spoon\" ] }",
+                    "misses expected element $.items[2]"
+                };
+                yield return new object[]
+                {
+                    "{ items: [ \"fork\", \"knife\" , \"spoon\" ] }",
+                    "{ items: [ \"fork\", \"spoon\", \"knife\" ] }",
+                    "has expected element $.items[2] in the wrong order"
+                };
+                yield return new object[]
+                {
+                    "{ items: [ \"fork\", \"knife\" , \"spoon\" ] }",
+                    "{ items: [ \"fork\", \"fork\" ] }",
+                    "has a different value at $.items[1]"
+                };
+                yield return new object[]
+                {
+                    "{ tree: { } }",
+                    "{ tree: \"oak\" }",
+                    "has an object instead of a string at $.tree"
+                };
+                yield return new object[]
+                {
+                    "{ tree: { leaves: 10} }",
+                    "{ tree: { branches: 5, leaves: 10 } }",
+                    "misses property $.tree.branches"
+                };
+                yield return new object[]
+                {
+                    "{ tree: { leaves: 5 } }",
+                    "{ tree: { leaves: 10} }",
+                    "has a different value at $.tree.leaves"
+                };
+                yield return new object[]
+                {
+                    "{ eyes: \"blue\" }",
+                    "{ eyes: [] }",
+                    "has a string instead of an array at $.eyes"
+                };
+                yield return new object[]
+                {
+                    "{ eyes: \"blue\" }",
+                    "{ eyes: 2 }",
+                    "has a string instead of an integer at $.eyes"
+                };
+                yield return new object[]
+                {
+                    "{ id: 1 }",
+                    "{ id: 2 }",
+                    "has a different value at $.id"
+                };
+                yield return new object[]
+                {
+                    "{ items: [ { id: 1 }, { id: 3 }, { id: 5 } ] }",
+                    "{ items: [ { id: 1 }, { id: 2 } ] }",
+                    "has a different value at $.items[1].id"
+                };
+                yield return new object[]
+                {
+                    "{ foo: '1' }",
+                    "{ foo: 1 }",
+                    "has a string instead of an integer at $.foo"
+                };
+                yield return new object[]
+                {
+                    "{ foo: 'foo', bar: 'bar', child: { x: 1, y: 2, grandchild: { tag: 'abrakadabra' } } }",
+                    "{ child: { grandchild: { tag: 'ooops' } } }",
+                    "has a different value at $.child.grandchild.tag"
+                };
+            }
         }
 
-        [Fact]
-        public void When_property_types_dont_match_ContainSubtree_should_fail()
+        [Theory, MemberData(nameof(FailingContainSubtreeCases))]
+        public void When_some_JSON_does_not_contain_all_elements_from_a_subtree_it_should_throw(
+            string actualJson, string expectedJson, string expectedDifference)
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            var subject = JToken.Parse("{ foo: '1' } ");
+            var actual = (actualJson != null) ? JToken.Parse(actualJson) : null;
+            var expected = (expectedJson != null) ? JToken.Parse(expectedJson) : null;
 
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => subject.Should().ContainSubtree(" { foo: 1 } ");
+            Action action = () => actual.Should().ContainSubtree(expected);
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
-            act.Should().Throw<XunitException>();
+            action.Should().Throw<XunitException>()
+                .WithMessage(
+                    $"JSON document {expectedDifference}.{Environment.NewLine}" +
+                    $"Actual document{Environment.NewLine}" +
+                    $"{Format(actual, true)}{Environment.NewLine}" +
+                    $"was expected to contain{Environment.NewLine}" +
+                    $"{Format(expected, true)}.{Environment.NewLine}");
         }
 
         [Fact]


### PR DESCRIPTION
* Also require strict order for elements in an array when checking subtree

Before this PR `ContainSubtree` would just reporing `some elements were missing`, which is not very informative. Now the same logic and messages from `BeEquivalentTo` are reused, except that extra properties on the SUT are ignored.
When comparing arrays, elements that have a match are skipped for the consecutive elements to compare. Which means that element that are expected multiple times, should really appear multiple times in the SUT, and also the order becomes important. 