### PR TITLE
Added ShouldBeJsonSerializable

### DIFF
--- a/Src/FluentAssertions.Json/ObjectAssertionsExtensions.cs
+++ b/Src/FluentAssertions.Json/ObjectAssertionsExtensions.cs
@@ -23,6 +23,7 @@ namespace FluentAssertions.Json
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<ObjectAssertions> BeJsonSerializable(this ObjectAssertions assertions, string because = "", params object[] becauseArgs)
         {
             return BeJsonSerializable<object>(assertions, options => options, because, becauseArgs);
@@ -40,6 +41,7 @@ namespace FluentAssertions.Json
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<ObjectAssertions> BeJsonSerializable<T>(this ObjectAssertions assertions, string because = "", params object[] becauseArgs)
         {
             return BeJsonSerializable<T>(assertions, options => options, because, becauseArgs);
@@ -58,6 +60,7 @@ namespace FluentAssertions.Json
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         /// <param name="assertions"></param>
+        [CustomAssertion]
         public static AndConstraint<ObjectAssertions> BeJsonSerializable<T>(this ObjectAssertions assertions, Func<EquivalencyAssertionOptions<T>, EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion.ForCondition(assertions.Subject != null)

--- a/Src/FluentAssertions.Json/ObjectAssertionsExtensions.cs
+++ b/Src/FluentAssertions.Json/ObjectAssertionsExtensions.cs
@@ -79,9 +79,7 @@ namespace FluentAssertions
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {0} to be JSON serializable{reason}, but serialization failed with:\r\n\r\n{1}",
-                        assertions.Subject,
-                        exc.Message);
+                    .FailWith("Expected {object:context} to be JSON serializable{reason}, but serializing {0} failed with {1}", assertions.Subject, exc);
             }
 
             return new AndConstraint<ObjectAssertions>(assertions);

--- a/Src/FluentAssertions.Json/ObjectAssertionsExtensions.cs
+++ b/Src/FluentAssertions.Json/ObjectAssertionsExtensions.cs
@@ -4,10 +4,7 @@ using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 using Newtonsoft.Json;
 
-// added to the root namespace to aid discovery
-// ReSharper disable CheckNamespace
-namespace FluentAssertions
-// ReSharper restore CheckNamespace
+namespace FluentAssertions.Json
 {
     /// <summary>
     ///     Contains extension methods for JSON serialization assertion methods
@@ -89,7 +86,7 @@ namespace FluentAssertions
         {
             var serializedObject = JsonConvert.SerializeObject(subject);
             var cloneUsingJsonSerializer = JsonConvert.DeserializeObject(serializedObject, subject.GetType());
-            return cloneUsingJsonSerializer; ;
+            return cloneUsingJsonSerializer;
         }
     }
 }

--- a/Src/FluentAssertions.Json/ObjectAssertionsExtensions.cs
+++ b/Src/FluentAssertions.Json/ObjectAssertionsExtensions.cs
@@ -60,6 +60,14 @@ namespace FluentAssertions.Json
         /// <param name="assertions"></param>
         public static AndConstraint<ObjectAssertions> BeJsonSerializable<T>(this ObjectAssertions assertions, Func<EquivalencyAssertionOptions<T>, EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs)
         {
+            Execute.Assertion.ForCondition(assertions.Subject != null)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:object} to be JSON serializable{reason}, but the value is null.  Please provide a value for the assertion.");
+
+            Execute.Assertion.ForCondition(assertions.Subject is T)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:object} to be JSON serializable{reason}, but {context:object} is not assignable to {0}", typeof(T));
+
             try
             {
                 var deserializedObject = CreateCloneUsingJsonSerializer(assertions.Subject);
@@ -76,7 +84,7 @@ namespace FluentAssertions.Json
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {object:context} to be JSON serializable{reason}, but serializing {0} failed with {1}", assertions.Subject, exc);
+                    .FailWith("Expected {context:object} to be JSON serializable{reason}, but serializing {0} failed with {1}", assertions.Subject, exc);
             }
 
             return new AndConstraint<ObjectAssertions>(assertions);

--- a/Src/FluentAssertions.Json/ObjectAssertionsExtensions.cs
+++ b/Src/FluentAssertions.Json/ObjectAssertionsExtensions.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using FluentAssertions.Equivalency;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+using Newtonsoft.Json;
+
+// added to the root namespace to aid discovery
+// ReSharper disable CheckNamespace
+namespace FluentAssertions
+// ReSharper restore CheckNamespace
+{
+    /// <summary>
+    ///     Contains extension methods for JSON serialization assertion methods
+    /// </summary>
+    public static class ObjectAssertionsExtensions
+    {
+        /// <summary>
+        /// Asserts that an object can be serialized and deserialized using the JSON serializer and that it stills retains
+        /// the values of all members.
+        /// </summary>
+        /// <param name="assertions"></param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public static AndConstraint<ObjectAssertions> BeJsonSerializable(this ObjectAssertions assertions, string because = "", params object[] becauseArgs)
+        {
+            return BeJsonSerializable<object>(assertions, options => options, because, becauseArgs);
+        }
+
+        /// <summary>
+        /// Asserts that an object can be serialized and deserialized using the JSON serializer and that it stills retains
+        /// the values of all members.
+        /// </summary>
+        /// <param name="assertions"></param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public static AndConstraint<ObjectAssertions> BeJsonSerializable<T>(this ObjectAssertions assertions, string because = "", params object[] becauseArgs)
+        {
+            return BeJsonSerializable<T>(assertions, options => options, because, becauseArgs);
+        }
+
+        /// <summary>
+        /// Asserts that an object can be serialized and deserialized using the JSON serializer and that it stills retains
+        /// the values of all members.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        /// <param name="assertions"></param>
+        public static AndConstraint<ObjectAssertions> BeJsonSerializable<T>(this ObjectAssertions assertions, Func<EquivalencyAssertionOptions<T>, EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs)
+        {
+            try
+            {
+                var deserializedObject = CreateCloneUsingJsonSerializer(assertions.Subject);
+
+                var defaultOptions = AssertionOptions.CloneDefaults<T>()
+                    .RespectingRuntimeTypes()
+                    .IncludingFields()
+                    .IncludingProperties();
+
+                var typedSubject = (T)assertions.Subject;
+                ((T)deserializedObject).Should().BeEquivalentTo(typedSubject, _ => options(defaultOptions));
+            }
+            catch (Exception exc)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {0} to be JSON serializable{reason}, but serialization failed with:\r\n\r\n{1}",
+                        assertions.Subject,
+                        exc.Message);
+            }
+
+            return new AndConstraint<ObjectAssertions>(assertions);
+        }
+
+        private static object CreateCloneUsingJsonSerializer(object subject)
+        {
+            var serializedObject = JsonConvert.SerializeObject(subject);
+            var cloneUsingJsonSerializer = JsonConvert.DeserializeObject(serializedObject, subject.GetType());
+            return cloneUsingJsonSerializer; ;
+        }
+    }
+}

--- a/Tests/FluentAssertions.Json.Specs/FluentAssertions.Json.Specs.csproj
+++ b/Tests/FluentAssertions.Json.Specs/FluentAssertions.Json.Specs.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AutoFixture" Version="4.17.0" />
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
         <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/Tests/FluentAssertions.Json.Specs/Models/AddressDto.cs
+++ b/Tests/FluentAssertions.Json.Specs/Models/AddressDto.cs
@@ -1,0 +1,13 @@
+﻿namespace FluentAssertions.Json.Specs.Models
+{
+    // ReSharper disable UnusedMember.Global
+
+    public class AddressDto
+    {
+        public string AddressLine1{ get; set; }
+        public string AddressLine2{ get; set; }
+        public string AddressLine3{ get; set; }
+    }
+    // ReSharper restore UnusedMember.Global
+
+}

--- a/Tests/FluentAssertions.Json.Specs/Models/EmploymentDto.cs
+++ b/Tests/FluentAssertions.Json.Specs/Models/EmploymentDto.cs
@@ -1,0 +1,12 @@
+﻿namespace FluentAssertions.Json.Specs.Models
+{
+    // ReSharper disable UnusedMember.Global
+
+    public class EmploymentDto
+    {
+        public string JobTitle{ get; set; }
+        public string PhoneNumber { get; set; }
+    }
+    // ReSharper restore UnusedMember.Global
+
+}

--- a/Tests/FluentAssertions.Json.Specs/Models/PocoWithIgnoredProperty.cs
+++ b/Tests/FluentAssertions.Json.Specs/Models/PocoWithIgnoredProperty.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+
+namespace FluentAssertions.Json.Specs.Models
+{
+    public class PocoWithIgnoredProperty
+    {
+        public int Id { get; set; }
+
+        [JsonIgnore]
+        public string Name{ get; set; }
+    }
+}

--- a/Tests/FluentAssertions.Json.Specs/Models/PocoWithNoDefaultConstructor.cs
+++ b/Tests/FluentAssertions.Json.Specs/Models/PocoWithNoDefaultConstructor.cs
@@ -1,0 +1,16 @@
+﻿namespace FluentAssertions.Json.Specs.Models
+{
+    public class PocoWithNoDefaultConstructor
+    {
+        public int Id { get; }
+
+        /// <summary>
+        /// Newtonsoft.Json will deserialise this successfully if the parameter name id the same as the property
+        /// </summary>
+        /// <param name="value">DO NOT CHANGE THE NAME OF THIS PARAMETER</param>
+        public PocoWithNoDefaultConstructor(int value)
+        {
+            Id = value;
+        }
+    }
+}

--- a/Tests/FluentAssertions.Json.Specs/Models/PocoWithStructure.cs
+++ b/Tests/FluentAssertions.Json.Specs/Models/PocoWithStructure.cs
@@ -1,0 +1,12 @@
+﻿namespace FluentAssertions.Json.Specs.Models
+{
+    // ReSharper disable UnusedMember.Global
+    public class PocoWithStructure
+    {
+        public int Id{ get; set; }
+        public AddressDto Address { get; set; }
+        public EmploymentDto Employment { get; set; }
+    }
+    // ReSharper restore UnusedMember.Global
+
+}

--- a/Tests/FluentAssertions.Json.Specs/Models/SimplePocoWithPrimitiveTypes.cs
+++ b/Tests/FluentAssertions.Json.Specs/Models/SimplePocoWithPrimitiveTypes.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace FluentAssertions.Json.Specs.Models
+{
+    // ReSharper disable UnusedMember.Global
+    public class SimplePocoWithPrimitiveTypes
+    {
+        public int Id { get; set; }
+        public Guid GlobalId { get; set; }
+        public string Name { get; set; }
+        public DateTime DateOfBirth { get; set; }
+        public decimal Height { get; set; }
+        public double Weight { get; set; }
+        public float ShoeSize { get; set; }
+        public bool IsActive { get; set; }
+
+        public byte[] Image { get; set; }
+        public char Category { get; set; }
+    }
+    // ReSharper restore UnusedMember.Global
+}

--- a/Tests/FluentAssertions.Json.Specs/ShouldBeJsonSerializableTests.cs
+++ b/Tests/FluentAssertions.Json.Specs/ShouldBeJsonSerializableTests.cs
@@ -20,7 +20,7 @@ namespace SomeOtherNamespace
         }
 
         [Fact]
-        public void Class_is_simple_poco_should_be_serializable()
+        public void Simple_poco_should_be_serializable()
         {
             // arrange
             var target = _fixture.Create<SimplePocoWithPrimitiveTypes>();
@@ -33,7 +33,7 @@ namespace SomeOtherNamespace
         }
 
         [Fact]
-        public void Class_is_complex_poco_should_be_serializable()
+        public void Complex_poco_should_be_serializable()
         {
             // arrange
             var target = _fixture.Create<PocoWithStructure>();
@@ -46,7 +46,7 @@ namespace SomeOtherNamespace
         }
 
         [Fact]
-        public void Class_does_not_have_default_constructor()
+        public void Class_that_does_not_have_default_constructor_should_not_be_serializable()
         {
             // arrange
             const string reasonText = "this is the reason";
@@ -65,7 +65,7 @@ namespace SomeOtherNamespace
         }
 
         [Fact]
-        public void Class_has_ignored_property()
+        public void Class_that_has_ignored_property_should_not_be_serializable_if_equivalency_options_are_not_configured()
         {
             // arrange
             const string reasonText = "this is the reason";
@@ -84,7 +84,7 @@ namespace SomeOtherNamespace
         }
 
         [Fact]
-        public void Class_has_ignored_property_equivalency_options_are_configured()
+        public void Class_that_has_ignored_property_should_be_serializable_when_equivalency_options_are_configured()
         {
             // arrange
             var target = _fixture.Create<PocoWithIgnoredProperty>();

--- a/Tests/FluentAssertions.Json.Specs/ShouldBeJsonSerializableTests.cs
+++ b/Tests/FluentAssertions.Json.Specs/ShouldBeJsonSerializableTests.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using AutoFixture;
+using FluentAssertions;
+using FluentAssertions.Json.Specs.Models;
+using Xunit;
+
+// NOTE that we are using both namespaces 'FluentAssertions' & 'FluentAssertions.Json' from an external namespace to force compiler disambiguation warnings
+// ReSharper disable CheckNamespace
+namespace SomeOtherNamespace
+// ReSharper restore CheckNamespace
+{
+    public class ShouldBeJsonSerializableTests
+    {
+        private readonly Fixture _fixture;
+
+        public ShouldBeJsonSerializableTests()
+        {
+            _fixture = new Fixture();
+        }
+
+        [Fact]
+        public void Class_is_simple_poco_should_be_serializable()
+        {
+            // arrange
+            var target = _fixture.Create<SimplePocoWithPrimitiveTypes>();
+
+            // act
+            Action act = () => target.Should().BeJsonSerializable();
+
+            // assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Class_is_complex_poco_should_be_serializable()
+        {
+            // arrange
+            var target = _fixture.Create<PocoWithStructure>();
+
+            // act
+            Action act = () => target.Should().BeJsonSerializable();
+
+            // assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Class_does_not_have_default_constructor()
+        {
+            // arrange
+            var target = _fixture.Create<PocoWithNoDefaultConstructor>();
+
+            // act
+            Action act = () => target.Should().BeJsonSerializable();
+
+            // assert
+            act.Should().Throw<Xunit.Sdk.XunitException>();
+        }
+
+        [Fact]
+        public void Class_has_ignored_property()
+        {
+            // arrange
+            var target = _fixture.Create<PocoWithIgnoredProperty>();
+
+            // act
+            Action act = () => target.Should().BeJsonSerializable();
+
+            // assert
+            act.Should().Throw<Xunit.Sdk.XunitException>();
+        }
+
+        [Fact]
+        public void Class_has_ignored_property_equivalency_options_are_configured()
+        {
+            // arrange
+            var target = _fixture.Create<PocoWithIgnoredProperty>();
+
+            // act
+            Action act = () => target.Should().BeJsonSerializable<PocoWithIgnoredProperty>(opts => opts.Excluding(p => p.Name));
+
+            // assert
+            act.Should().NotThrow();
+        }
+
+    }
+
+}
+

--- a/Tests/FluentAssertions.Json.Specs/ShouldBeJsonSerializableTests.cs
+++ b/Tests/FluentAssertions.Json.Specs/ShouldBeJsonSerializableTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using AutoFixture;
 using FluentAssertions;
+using FluentAssertions.Json;
 using FluentAssertions.Json.Specs.Models;
 using Xunit;
 

--- a/Tests/FluentAssertions.Json.Specs/ShouldBeJsonSerializableTests.cs
+++ b/Tests/FluentAssertions.Json.Specs/ShouldBeJsonSerializableTests.cs
@@ -49,26 +49,38 @@ namespace SomeOtherNamespace
         public void Class_does_not_have_default_constructor()
         {
             // arrange
+            const string reasonText = "this is the reason";
             var target = _fixture.Create<PocoWithNoDefaultConstructor>();
 
             // act
-            Action act = () => target.Should().BeJsonSerializable();
+            Action act = () => target.Should().BeJsonSerializable(reasonText);
 
             // assert
-            act.Should().Throw<Xunit.Sdk.XunitException>();
+            act.Should().Throw<Xunit.Sdk.XunitException>()
+                .Which.Message.Should()
+                    .Contain("to be JSON serializable")
+                    .And.Contain(reasonText)
+                    .And.Contain("but serializing")
+                    .And.Contain("failed with");
         }
 
         [Fact]
         public void Class_has_ignored_property()
         {
             // arrange
+            const string reasonText = "this is the reason";
             var target = _fixture.Create<PocoWithIgnoredProperty>();
 
             // act
-            Action act = () => target.Should().BeJsonSerializable();
+            Action act = () => target.Should().BeJsonSerializable(reasonText);
 
             // assert
-            act.Should().Throw<Xunit.Sdk.XunitException>();
+            act.Should().Throw<Xunit.Sdk.XunitException>()
+                .Which.Message.Should()
+                    .Contain("to be JSON serializable")
+                    .And.Contain(reasonText)
+                    .And.Contain("but serializing")
+                    .And.Contain("failed with");
         }
 
         [Fact]
@@ -82,6 +94,40 @@ namespace SomeOtherNamespace
 
             // assert
             act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Should_fail_when_instance_is_null()
+        {
+            // arrange
+            const SimplePocoWithPrimitiveTypes target = null;
+
+            // act
+            Action act = () => target.Should().BeJsonSerializable();
+
+            // assert
+            act.Should()
+                .Throw<Xunit.Sdk.XunitException>(because:"This is consistent with BeBinarySerializable() and BeDataContractSerializable()")
+                .Which.Message
+                    .Should().Contain("value is null")
+                        .And.Contain("Please provide a value for the assertion");
+        }
+
+        [Fact]
+        public void Should_fail_when_subject_is_not_same_type_as_the_specified_generic_type()
+        {
+            // arrange
+            var target = new AddressDto();
+
+            // act
+            Action act = () => target.Should().BeJsonSerializable<SimplePocoWithPrimitiveTypes>();
+
+            // assert
+            act.Should().Throw<Xunit.Sdk.XunitException>(because: "This is consistent with BeBinarySerializable() and BeDataContractSerializable()")
+                .Which.Message
+                    .Should().Contain("is not assignable to")
+                        .And.Contain(nameof(SimplePocoWithPrimitiveTypes));
+                ;
         }
 
     }


### PR DESCRIPTION
Added ShouldBeJsonSerializable (see #3 )
Note: I've added the extension to the root namespace (__FluentAssertions__) to aid discovery.

This is based on a previous PR[1] by @borismod that was never merged

[1] https://github.com/fluentassertions/fluentassertions.json/commit/54432fdebc39e8ac52f5c9a0a30c08bdab01bbcf